### PR TITLE
setting CMS_CASCADE_BOOTSTRAP3_COLUMN_ALLOW_PLUGINS

### DIFF
--- a/cmsplugin_cascade/bootstrap3/container.py
+++ b/cmsplugin_cascade/bootstrap3/container.py
@@ -80,7 +80,7 @@ plugin_pool.register_plugin(BootstrapRowPlugin)
 class BootstrapColumnPlugin(BootstrapPluginBase):
     name = _("Column")
     parent_classes = ['BootstrapRowPlugin']
-    generic_child_classes = ('TextPlugin', 'FilerImagePlugin',)
+    generic_child_classes = settings.CMS_CASCADE_BOOTSTRAP3_COLUMN_ALLOW_PLUGINS
     default_width_widget = PartialFormField('xs-column-width',
         widgets.Select(choices=tuple(('col-xs-{0}'.format(i), ungettext_lazy('{0} unit', '{0} units', i).format(i))
                                      for i in range(1, 13))),

--- a/cmsplugin_cascade/bootstrap3/settings.py
+++ b/cmsplugin_cascade/bootstrap3/settings.py
@@ -2,3 +2,4 @@
 from django.conf import settings
 
 CMS_CASCADE_BOOTSTRAP3_BREAKPOINT = getattr(settings, 'CMS_CASCADE_BOOTSTRAP3_BREAKPOINT', 'lg')
+CMS_CASCADE_BOOTSTRAP3_COLUMN_ALLOW_PLUGINS = getattr(settings, 'CMS_CASCADE_BOOTSTRAP3_COLUMN_ALLOW_PLUGINS', ('TextPlugin', 'FilerImagePlugin',))

--- a/cmsplugin_cascade/plugin_base.py
+++ b/cmsplugin_cascade/plugin_base.py
@@ -18,11 +18,14 @@ class CascadePluginBase(CMSPluginBase):
     def _child_classes(self):
         """All registered plugins shall be allowed as children for this plugin"""
         result = list(getattr(self, 'generic_child_classes', [])) or []
-        for p in plugin_pool.get_all_plugins():
-            if isinstance(p.parent_classes, (list, tuple)) and self.__class__.__name__ in p.parent_classes \
-                and p.__name__ not in result:
-                result.append(p.__name__)
-        return result
+        if result:
+            for p in plugin_pool.get_all_plugins():
+                if isinstance(p.parent_classes, (list, tuple)) and self.__class__.__name__ in p.parent_classes \
+                    and p.__name__ not in result:
+                    result.append(p.__name__)
+            return result
+        else:
+            return None  # All classes will be available
     child_classes = property(_child_classes)
 
     def __init__(self, model=None, admin_site=None, partial_fields=None):


### PR DESCRIPTION
Allow developer define by himself plugins to render inside specified column.
