### PR TITLE
Add hint to dependency installation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,6 +3,10 @@
 Installation
 ============
 
+Install pandoc dependency on your system. For example on Debian::
+
+	$ sudo aptitude install pandoc
+
 Install the latest stable release::
 
 	$ pip install djangocms-cascade


### PR DESCRIPTION
Add a hint that you need to install pandoc before installing via pip.
