### PR TITLE
Change CMS_CASCADE_LEAF_PLUGINS to a dictionary for more configurable settings

### DIFF
--- a/cmsplugin_cascade/bootstrap3/carousel.py
+++ b/cmsplugin_cascade/bootstrap3/carousel.py
@@ -52,7 +52,10 @@ class SlidePlugin(BootstrapPluginBase):
     name = _("Slide")
     default_css_class = 'item'
     parent_classes = ['CarouselPlugin']
-    generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS
+    try:
+        generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS[framework]['SlidePlugin']
+    except KeyError:
+        generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS.get('default')
 
     @classmethod
     def get_css_classes(cls, obj):

--- a/cmsplugin_cascade/bootstrap3/container.py
+++ b/cmsplugin_cascade/bootstrap3/container.py
@@ -10,6 +10,7 @@ from cmsplugin_cascade.bootstrap3 import settings
 from cmsplugin_cascade.plugin_base import PartialFormField
 from cmsplugin_cascade.widgets import MultipleInlineStylesWidget
 from cmsplugin_cascade.bootstrap3.plugin_base import BootstrapPluginBase
+from cmsplugin_cascade.cms_plugins import framework
 
 
 class ContainerRadioFieldRenderer(RadioFieldRenderer):
@@ -82,7 +83,10 @@ plugin_pool.register_plugin(BootstrapRowPlugin)
 class BootstrapColumnPlugin(BootstrapPluginBase):
     name = _("Column")
     parent_classes = ['BootstrapRowPlugin']
-    generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS
+    try:
+        generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS[framework]['BootstrapColumnPlugin']
+    except KeyError:
+        generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS.get('default')
     default_width_widget = PartialFormField('xs-column-width',
         widgets.Select(choices=tuple(('col-xs-{0}'.format(i), ungettext_lazy('{0} unit', '{0} units', i).format(i))
                                      for i in range(1, 13))),

--- a/cmsplugin_cascade/bootstrap3/settings.py
+++ b/cmsplugin_cascade/bootstrap3/settings.py
@@ -2,4 +2,7 @@
 from django.conf import settings
 
 CMS_CASCADE_BOOTSTRAP3_BREAKPOINT = getattr(settings, 'CMS_CASCADE_BOOTSTRAP3_BREAKPOINT', 'lg')
-CMS_CASCADE_LEAF_PLUGINS = getattr(settings, 'CMS_CASCADE_LEAF_PLUGINS', ('TextPlugin', 'FilerImagePlugin',))
+CMS_CASCADE_LEAF_PLUGINS = {
+    'default': ('TextPlugin', 'FilerImagePlugin',),
+}
+CMS_CASCADE_LEAF_PLUGINS.update(getattr(settings, 'CMS_CASCADE_LEAF_PLUGINS', {}))

--- a/cmsplugin_cascade/bootstrap3/wrappers.py
+++ b/cmsplugin_cascade/bootstrap3/wrappers.py
@@ -6,12 +6,16 @@ from cmsplugin_cascade.plugin_base import PartialFormField
 from cmsplugin_cascade.widgets import MultipleInlineStylesWidget
 from cmsplugin_cascade.bootstrap3 import settings
 from cmsplugin_cascade.bootstrap3.plugin_base import BootstrapPluginBase
+from cmsplugin_cascade.cms_plugins import framework
 
 
 class SimpleWrapperPlugin(BootstrapPluginBase):
     name = _("Simple Wrapper")
     parent_classes = ['BootstrapColumnPlugin']
-    generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS
+    try:
+        generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS[framework]['SimpleWrapperPlugin']
+    except KeyError:
+        generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS.get('default')
     CLASS_CHOICES = ((('', _('Unstyled')),) + tuple((cls, cls.title()) for cls in ('thumbnail', 'jumbotron',)))
     partial_fields = (
         PartialFormField('css_class',

--- a/cmsplugin_cascade/gs960/grid.py
+++ b/cmsplugin_cascade/gs960/grid.py
@@ -5,6 +5,7 @@ from cms.plugin_pool import plugin_pool
 from cmsplugin_cascade.gs960 import settings
 from cmsplugin_cascade.plugin_base import CascadePluginBase, PartialFormField
 from cmsplugin_cascade.widgets import MultipleInlineStylesWidget
+from cmsplugin_cascade.cms_plugins import framework
 
 
 class Container960BasePlugin(CascadePluginBase):
@@ -57,7 +58,10 @@ class Grid960BasePlugin(CascadePluginBase):
     name = _("Grid")
     require_parent = True
     allow_children = True
-    generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS
+    try:
+        generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS[framework]['Grid960BasePlugin']
+    except KeyError:
+        generic_child_classes = settings.CMS_CASCADE_LEAF_PLUGINS.get('default')
     default_css_attributes = ('grid', 'prefix', 'suffix', 'options',)
     OPTION_CHOICES = (('alpha', _('Left aligned')), ('omega', _('Right aligned')),
                       ('clearfix', _('Clearfix')),)

--- a/cmsplugin_cascade/gs960/settings.py
+++ b/cmsplugin_cascade/gs960/settings.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
 
-CMS_CASCADE_LEAF_PLUGINS = getattr(settings, 'CMS_CASCADE_LEAF_PLUGINS', ('TextPlugin', 'FilerImagePlugin',))
+CMS_CASCADE_LEAF_PLUGINS = {
+    'default': ('TextPlugin', 'FilerImagePlugin',),
+}
+CMS_CASCADE_LEAF_PLUGINS.update(getattr(settings, 'CMS_CASCADE_LEAF_PLUGINS', {}))


### PR DESCRIPTION
See #5 and #6.

Putting default outside of any framework so no need to specify multiple default settings.
```
CMS_CASCADE_LEAF_PLUGINS = {
  'bootstrap3': {
    'SlidePlugin': ('FilerImagePlugin',)
  },
  'default': ('TextPlugin', 'FilerImagePlugin',),
}
```