### PR TITLE
use CMS_CASCADE_LEAF_PLUGINS from global settings.py

### DIFF
--- a/cmsplugin_cascade/bootstrap3/settings.py
+++ b/cmsplugin_cascade/bootstrap3/settings.py
@@ -2,14 +2,15 @@
 from django.conf import settings
 
 CMS_CASCADE_BOOTSTRAP3_BREAKPOINT = getattr(settings, 'CMS_CASCADE_BOOTSTRAP3_BREAKPOINT', 'lg')
+CMS_CASCADE_LEAF_PLUGINS = getattr(settings, 'CMS_CASCADE_LEAF_PLUGINS', [])
 
-if not hasattr(settings, 'CMS_CASCADE_LEAF_PLUGINS'):
-    CMS_CASCADE_LEAF_PLUGINS = []
+if not 'TextPlugin' in CMS_CASCADE_LEAF_PLUGINS:
     try:
         import djangocms_text_ckeditor
         CMS_CASCADE_LEAF_PLUGINS.append('TextPlugin')
     except ImportError:
         pass
+if not 'FilerImagePlugin' in CMS_CASCADE_LEAF_PLUGINS:
     try:
         import filer
         CMS_CASCADE_LEAF_PLUGINS.append('FilerImagePlugin')


### PR DESCRIPTION
- use CMS_CASCADE_LEAF_PLUGINS list from global settings, if it is defined there
- add TextPlugin, FilerImagePlugin if not in list
