### PR TITLE
Fix unicode problem

### DIFF
--- a/cmsplugin_cascade/widgets.py
+++ b/cmsplugin_cascade/widgets.py
@@ -52,7 +52,7 @@ class JSONMultiWidget(widgets.MultiWidget):
                 six.text_type(field.help_text)
             ))
         html = format_html_join('\n',
-            '<div class="glossary-widget glossary_{0}"><h1>{1}</h1><div class="glossary-box">{2}</div><small>{3}</small></div>',
+            u'<div class="glossary-widget glossary_{0}"><h1>{1}</h1><div class="glossary-box">{2}</div><small>{3}</small></div>',
             render_fields)
         return html
 


### PR DESCRIPTION
A plugin could cause Error 500s if there was unicode in a field
