### PR TITLE
add try around image.exif.get to avoid errors from boto

### DIFF
--- a/cmsplugin_cascade/bootstrap3/utils.py
+++ b/cmsplugin_cascade/bootstrap3/utils.py
@@ -28,7 +28,7 @@ def compute_aspect_ratio(image):
             return float(image.width) / float(image.height)
         else:
             return float(image.height) / float(image.width)
-    except:
+    except NotImplementedError:
         return float(image.height) / float(image.width)
 
 def get_responsive_appearances(context, instance):


### PR DESCRIPTION
When using boto for s3 storage, images give the error  : 
`This backend doesn't support absolute paths.`

I'm quite new to Django so there might be a better way of fixing this?
