### PR TITLE
Fix LinkForm: int() argument must be a string or a number, not 'Page' wh...

### DIFF
--- a/cmsplugin_cascade/link/forms.py
+++ b/cmsplugin_cascade/link/forms.py
@@ -91,9 +91,8 @@ class LinkForm(ModelForm):
 
     def set_initial_cmspage(self, initial):
         try:
-            Model = get_model(*initial['link']['model'].split('.'))
-            initial['cms_page'] = Model.objects.get(pk=initial['link']['pk'])
-        except (KeyError, ObjectDoesNotExist):
+            initial['cms_page'] = initial['link']['pk']
+        except KeyError:
             pass
 
     def set_initial_exturl(self, initial):


### PR DESCRIPTION
TypeError at /de/admin/cms/page/edit-plugin/12/
int() argument must be a string or a number, not 'Page'
Request Method:	GET
Request URL:	http://0.0.0.0:8000/de/admin/cms/page/edit-plugin/12/
Django Version:	1.7.2
Exception Type:	TypeError
Exception Value:	
int() argument must be a string or a number, not 'Page'
Exception Location:	/lib/python2.7/site-packages/django/db/models/fields/__init__.py in get_prep_value, line 915
Python Executable:/bin/python2.7
Python Version:	2.7.8