### PR TITLE
Fix a small documentation bug

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,7 @@ if you use Django-1.6
 
 .. code-block:: bash
 
-	./manage.py syncdb --migrate cmsplugin_cascade
+	./manage.py syncdb --migrate
 
 
 Install Bootstrap


### PR DESCRIPTION
``manage.py syncdb`` does not accept any arguments in Django 1.6.