### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/cmsplugin_cascade/extra_fields/mixins.py
+++ b/cmsplugin_cascade/extra_fields/mixins.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 try:
     from django.contrib.sites.shortcuts import get_current_site
 except ImportError:


### PR DESCRIPTION
Added Python 2.6 compatibility. Requires the backport package `ordereddict`.

Fixes import error `ImportError: cannot import name OrderedDict`