### PR TITLE
bootstrap3/image.py can now deal with deleted source image

### DIFF
--- a/cmsplugin_cascade/bootstrap3/image.py
+++ b/cmsplugin_cascade/bootstrap3/image.py
@@ -142,11 +142,12 @@ class BootstrapImagePlugin(LinkPluginBase):
     def render(self, context, instance, placeholder):
         is_responsive = 'img-responsive' in instance.glossary.get('image-shapes', [])
         tags = utils.get_image_tags(context, instance, is_responsive)
-        extra_styles = tags.pop('extra_styles')
-        inline_styles = instance.glossary.get('inline_styles', {})
-        inline_styles.update(extra_styles)
-        instance.glossary['inline_styles'] = inline_styles
-        context.update(dict(instance=instance, placeholder=placeholder, **tags))
+        if tags:
+            extra_styles = tags.pop('extra_styles')
+            inline_styles = instance.glossary.get('inline_styles', {})
+            inline_styles.update(extra_styles)
+            instance.glossary['inline_styles'] = inline_styles
+            context.update(dict(instance=instance, placeholder=placeholder, **tags))
         return context
 
     @classmethod


### PR DESCRIPTION
added condition to test for valid tags in bootstrap3/image.py to prevent tag=None error when source image to the plugin no longer exists (deleted in filer plugin)