### PR TITLE
Fixed a problem with MIGRATION_MODULES so that tests are passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 env:
   - DJANGO=1.6.11 MIGRATE='true'
-#  - DJANGO=1.7.7 MIGRATE='./manage.py migrate --settings=bs3demo.settings'
+  - DJANGO=1.7.8 MIGRATE='./manage.py migrate --settings=bs3demo.settings'
 
 branches:
   only:

--- a/cmsplugin_cascade/migrations/0003_inlinecascadeelement.py
+++ b/cmsplugin_cascade/migrations/0003_inlinecascadeelement.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_cascade', '0002_auto_20150530_1018'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='InlineCascadeElement',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('glossary', jsonfield.fields.JSONField(default={}, blank=True)),
+                ('cascade_element', models.ForeignKey(related_name='inline_elements', to='cmsplugin_cascade.CascadeElement')),
+            ],
+            options={
+                'db_table': 'cmsplugin_cascade_inline',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/examples/bs3demo/settings.py
+++ b/examples/bs3demo/settings.py
@@ -76,6 +76,10 @@ MIDDLEWARE_CLASSES = (
     'cms.middleware.language.LanguageCookieMiddleware',
 )
 
+# silence false-positive warning 1_6.W001
+# https://docs.djangoproject.com/en/1.8/ref/checks/#backwards-compatibility
+TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+
 # Absolute path to the directory that holds media.
 if django.VERSION[:2] > (1, 6):
     MEDIA_ROOT = os.path.join(PROJECT_DIR, 'media')

--- a/examples/bs3demo/settings.py
+++ b/examples/bs3demo/settings.py
@@ -1,6 +1,7 @@
 # Django settings for unit test project.
 import os
 import sys
+from .utils import find_django_migrations_module
 
 DEBUG = True
 
@@ -26,21 +27,6 @@ else:
 
 from cms import __version__ as CMS_VERSION
 CMS_VERSION = tuple(int(n) for n in CMS_VERSION.split('.')[:2])
-
-def get_django_migrations(module_name):
-    """ Tries to locate <module_name>.migrations_django.
-    Returns either "migrations_django" or "migrations".
-    For details why:
-      https://docs.djangoproject.com/en/1.7/topics/migrations/#libraries-third-party-apps
-    """
-    import imp
-    try:
-        module_info = imp.find_module(module_name)
-        module = imp.load_module(module_name, *module_info)
-        imp.find_module('migrations_django', module.__path__)
-        return 'migrations_django'
-    except ImportError:
-        return 'migrations'  # conforms to Django 1.7 defaults
 
 INSTALLED_APPS = (
     'django.contrib.auth',
@@ -68,10 +54,10 @@ INSTALLED_APPS = (
 )
 if django.VERSION[:2] >= (1, 7):
     MIGRATION_MODULES = {
-        'cms': 'cms.' + get_django_migrations('cms'),
-        'menus': 'menus.' + get_django_migrations('menus'),
-        'djangocms_text_ckeditor': 'djangocms_text_ckeditor.' + get_django_migrations('djangocms_text_ckeditor'),
-        'cmsplugin_cascade': 'cmsplugin_cascade.' + get_django_migrations('cmsplugin_cascade'),
+        'cms': find_django_migrations_module('cms'),
+        'menus': find_django_migrations_module('menus'),
+        'djangocms_text_ckeditor': find_django_migrations_module('djangocms_text_ckeditor'),
+        'cmsplugin_cascade': find_django_migrations_module('cmsplugin_cascade'),
     }
 else:
     INSTALLED_APPS += ('south',)

--- a/examples/bs3demo/settings.py
+++ b/examples/bs3demo/settings.py
@@ -27,6 +27,21 @@ else:
 from cms import __version__ as CMS_VERSION
 CMS_VERSION = tuple(int(n) for n in CMS_VERSION.split('.')[:2])
 
+def get_django_migrations(module_name):
+    """ Tries to locate <module_name>.migrations_django.
+    Returns either "migrations_django" or "migrations".
+    For details why:
+      https://docs.djangoproject.com/en/1.7/topics/migrations/#libraries-third-party-apps
+    """
+    import imp
+    try:
+        module_info = imp.find_module(module_name)
+        module = imp.load_module(module_name, *module_info)
+        imp.find_module('migrations_django', module.__path__)
+        return 'migrations_django'
+    except ImportError:
+        return 'migrations'  # conforms to Django 1.7 defaults
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -53,10 +68,10 @@ INSTALLED_APPS = (
 )
 if django.VERSION[:2] >= (1, 7):
     MIGRATION_MODULES = {
-        'cms': 'cms.migrations_django',
-        'menus': 'menus.migrations_django',
-        'djangocms_text_ckeditor': 'djangocms_text_ckeditor.migrations_django',
-        'cmsplugin_cascade': 'cmsplugin_cascade.migrations',
+        'cms': 'cms.' + get_django_migrations('cms'),
+        'menus': 'menus.' + get_django_migrations('menus'),
+        'djangocms_text_ckeditor': 'djangocms_text_ckeditor.' + get_django_migrations('djangocms_text_ckeditor'),
+        'cmsplugin_cascade': 'cmsplugin_cascade.' + get_django_migrations('cmsplugin_cascade'),
     }
 else:
     INSTALLED_APPS += ('south',)

--- a/examples/bs3demo/utils.py
+++ b/examples/bs3demo/utils.py
@@ -1,0 +1,15 @@
+
+def find_django_migrations_module(module_name):
+    """ Tries to locate <module_name>.migrations_django (without actually importing it).
+    Appends either ".migrations_django" or ".migrations" to module_name.
+    For details why:
+      https://docs.djangoproject.com/en/1.7/topics/migrations/#libraries-third-party-apps
+    """
+    import imp
+    try:
+        module_info = imp.find_module(module_name)
+        module = imp.load_module(module_name, *module_info)
+        imp.find_module('migrations_django', module.__path__)
+        return module_name + '.migrations_django'
+    except ImportError:
+        return module_name + '.migrations'  # conforms to Django 1.7 defaults


### PR DESCRIPTION
Some DjangoCMS plugins are keeping their migrations in `migrations` directory, and some still keep it in `migrations_django`. I've implemented a simple func that chooses which path is correct, by attempting to locate the older `migrations_django` package. This should hold for a while before all plugins transition to the new structure, then can be removed.

Also added what seems to be a missing migration for InlineCascadeElement.