### PR TITLE
Fix for reversion problem

### DIFF
--- a/cmsplugin_cascade/plugin_base.py
+++ b/cmsplugin_cascade/plugin_base.py
@@ -8,6 +8,7 @@ from django.utils.safestring import SafeText
 from cms.plugin_pool import plugin_pool
 from cms.plugin_base import CMSPluginBaseMetaclass, CMSPluginBase
 from cms.utils.placeholder import get_placeholder_conf
+from cms.utils.compat.dj import is_installed
 from .models_base import CascadeModelBase
 from .models import CascadeElement, SharableCascadeElement
 from .sharable.forms import SharableGlossaryMixin
@@ -56,6 +57,9 @@ class CascadePluginBaseMetaclass(CMSPluginBaseMetaclass):
             bases = tuple(import_by_path(mc) for mc in settings.CASCADE_SEGMENTATION_MIXINS) + bases
         model_mixins = attrs.pop('model_mixins', ())
         attrs['model'] = create_proxy_model(name, model_mixins, base_model)
+        if is_installed('reversion'):
+            import reversion
+            reversion.register(attrs['model'])
         return super(CascadePluginBaseMetaclass, cls).__new__(cls, name, bases, attrs)
 
 

--- a/examples/bs3demo/requirements.txt
+++ b/examples/bs3demo/requirements.txt
@@ -19,3 +19,4 @@ jsonfield
 pyflakes
 six
 wsgiref
+django-reversion

--- a/examples/bs3demo/settings.py
+++ b/examples/bs3demo/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.staticfiles',
     'django.contrib.sitemaps',
+    'reversion',
     'djangocms_text_ckeditor',
     'django_select2',
     'cmsplugin_cascade',

--- a/examples/bs3demo/tests/test_http.py
+++ b/examples/bs3demo/tests/test_http.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from cms.api import create_page
+from cms.test_utils.testcases import CMSTestCase, URL_CMS_PLUGIN_ADD
+from cms.utils.compat.dj import is_installed
+from django.contrib import admin
+from django.test import Client
+from django.test.utils import modify_settings
+
+
+class ContainerPluginTest(CMSTestCase):
+    def setUp(self):
+        self.page = create_page('HOME', 'testing.html', 'en-us', published=True, in_navigation=True)
+        self.placeholder = self.page.placeholders.get(slot='Main Content')
+        self.admin_site = admin.sites.AdminSite()
+        self.user = self.get_superuser()
+        self.password = "top_secret"
+        self.user.set_password(self.password)
+        self.user.save()
+        self.client.login(username=self.user.username, password=self.password)
+
+    @modify_settings(INSTALLED_APPS={
+        'remove': 'reversion',
+    })
+    def test_without_reversion(self):
+        self.assertFalse(is_installed('reversion'))
+        response = self.client.post(
+            URL_CMS_PLUGIN_ADD[3:],
+            data={
+                'plugin_parent': '',
+                'plugin_type': 'BootstrapContainerPlugin',
+                'plugin_language': 'en-us',
+                'placeholder_id': self.placeholder.id,
+            },
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_with_reversion(self):
+        self.assertTrue(is_installed('reversion'))
+        response = self.client.post(
+            URL_CMS_PLUGIN_ADD[3:],
+            data={
+                'plugin_parent': '',
+                'plugin_type': 'BootstrapContainerPlugin',
+                'plugin_language': 'en-us',
+                'placeholder_id': unicode(self.placeholder.id),
+            },
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        self.assertEqual(response.status_code, 200)

--- a/examples/bs3demo/tests/test_http.py
+++ b/examples/bs3demo/tests/test_http.py
@@ -3,10 +3,12 @@ from __future__ import unicode_literals
 import json
 from django.conf import settings
 from django.contrib import admin
-from django.test import modify_settings
+from django.test.utils import override_settings
 from cms.models import Page
 from cms.utils.compat.dj import is_installed
 from cms.test_utils.testcases import CMSTestCase, URL_CMS_PAGE_ADD, URL_CMS_PLUGIN_ADD
+
+APPS_WITHOUT_REVERSION = [app for app in settings.INSTALLED_APPS if app != 'reversion']
 
 
 class ContainerPluginTest(CMSTestCase):
@@ -66,7 +68,7 @@ class ContainerPluginTest(CMSTestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @modify_settings(INSTALLED_APPS={'remove': 'reversion'})
+    @override_settings(INSTALLED_APPS=APPS_WITHOUT_REVERSION)
     def test_without_reversion(self):
         self.assertFalse(is_installed('reversion'))
         self._create_and_configure_a_container_plugin()

--- a/examples/bs3demo/tests/test_http.py
+++ b/examples/bs3demo/tests/test_http.py
@@ -1,51 +1,77 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from cms.api import create_page
-from cms.test_utils.testcases import CMSTestCase, URL_CMS_PLUGIN_ADD
-from cms.utils.compat.dj import is_installed
+import json
+from django.conf import settings
 from django.contrib import admin
-from django.test import Client
-from django.test.utils import modify_settings
+from django.test import modify_settings
+from cms.models import Page
+from cms.utils.compat.dj import is_installed
+from cms.test_utils.testcases import CMSTestCase, URL_CMS_PAGE_ADD, URL_CMS_PLUGIN_ADD
 
 
 class ContainerPluginTest(CMSTestCase):
     def setUp(self):
-        self.page = create_page('HOME', 'testing.html', 'en-us', published=True, in_navigation=True)
-        self.placeholder = self.page.placeholders.get(slot='Main Content')
         self.admin_site = admin.sites.AdminSite()
         self.user = self.get_superuser()
         self.password = "top_secret"
         self.user.set_password(self.password)
         self.user.save()
         self.client.login(username=self.user.username, password=self.password)
+        self.language = 'en-us'
+        self.site_id = settings.SITE_ID
 
-    @modify_settings(INSTALLED_APPS={
-        'remove': 'reversion',
-    })
-    def test_without_reversion(self):
-        self.assertFalse(is_installed('reversion'))
+        # create page
+        response = self.client.post(
+            URL_CMS_PAGE_ADD[3:],
+            data={
+                'language': self.language,
+                'site': self.site_id,
+                'template': 'INHERIT',
+                'title': 'HOME',
+                'slug': 'home',
+                '_save': 'Save',
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # get page and placeholder
+        self.page = Page.objects.get(publisher_is_draft=True, is_home=True)
+        self.placeholder = self.page.placeholders.get(slot='Main Content')
+
+    def _create_and_configure_a_container_plugin(self):
+        # create a plugin
         response = self.client.post(
             URL_CMS_PLUGIN_ADD[3:],
             data={
                 'plugin_parent': '',
                 'plugin_type': 'BootstrapContainerPlugin',
-                'plugin_language': 'en-us',
+                'plugin_language': self.language,
                 'placeholder_id': self.placeholder.id,
             },
             HTTP_X_REQUESTED_WITH='XMLHttpRequest',
         )
         self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content)
+        plugin_url = response_data['url']
+
+        # configure that plugin
+        response = self.client.post(
+            plugin_url,
+            data={
+                '_popup': '1',
+                'breakpoints': ['xs', 'lg'],
+                '_save': 'Save',
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @modify_settings(INSTALLED_APPS={'remove': 'reversion'})
+    def test_without_reversion(self):
+        self.assertFalse(is_installed('reversion'))
+        self._create_and_configure_a_container_plugin()
 
     def test_with_reversion(self):
         self.assertTrue(is_installed('reversion'))
-        response = self.client.post(
-            URL_CMS_PLUGIN_ADD[3:],
-            data={
-                'plugin_parent': '',
-                'plugin_type': 'BootstrapContainerPlugin',
-                'plugin_language': 'en-us',
-                'placeholder_id': unicode(self.placeholder.id),
-            },
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
-        )
-        self.assertEqual(response.status_code, 200)
+        self._create_and_configure_a_container_plugin()
+


### PR DESCRIPTION
This should fix the problem with django-reversion: https://github.com/jrief/djangocms-cascade/issues/50
Fix proposed by @aer0s in the referenced issue. I added a conditional check and some tests.

An interesting thing is that I could not reproduce the problem in tests using DjangoCMS API alone, those tests worked fine. Instead had to simulate the "normal user workflow", i.e. HTTP requests that create and configure plugins. Only then did the problem got triggered.

Tested on Python 2.7.9 with Django 1.6.11 and 1.7.8.