### PR TITLE
Reordered glossary fields for Column plugin

### DIFF
--- a/cmsplugin_cascade/bootstrap3/container.py
+++ b/cmsplugin_cascade/bootstrap3/container.py
@@ -253,8 +253,8 @@ class BootstrapColumnPlugin(BootstrapPluginBase):
                 glossary_fields.append(PartialFormField('{}-responsive-utils'.format(bp),
                     widgets.RadioSelect(choices=choices), label=label, help_text=help_text, initial=''))
         glossary_fields = [
-            glossary_fields[ i + len(glossary_fields) / len(breakpoints) * j]
-            for i in range(0, len(glossary_fields) / len(breakpoints))
+            glossary_fields[ i + len(glossary_fields) // len(breakpoints) * j]
+            for i in range(0, len(glossary_fields) // len(breakpoints))
             for j in range(0, len(breakpoints))
         ]
         kwargs.update(glossary_fields=glossary_fields)

--- a/cmsplugin_cascade/bootstrap3/container.py
+++ b/cmsplugin_cascade/bootstrap3/container.py
@@ -253,9 +253,9 @@ class BootstrapColumnPlugin(BootstrapPluginBase):
                 glossary_fields.append(PartialFormField('{}-responsive-utils'.format(bp),
                     widgets.RadioSelect(choices=choices), label=label, help_text=help_text, initial=''))
         glossary_fields = [
-            glossary_fields[i + len(breakpoints) * j]
-            for i in range(0, 3)
-            for j in range(0, len(glossary_fields) / len(breakpoints))
+            glossary_fields[ i + len(glossary_fields) / len(breakpoints) * j]
+            for i in range(0, len(glossary_fields) / len(breakpoints))
+            for j in range(0, len(breakpoints))
         ]
         kwargs.update(glossary_fields=glossary_fields)
         return super(BootstrapColumnPlugin, self).get_form(request, obj, **kwargs)

--- a/cmsplugin_cascade/bootstrap3/container.py
+++ b/cmsplugin_cascade/bootstrap3/container.py
@@ -195,7 +195,7 @@ class BootstrapColumnPlugin(BootstrapPluginBase):
                 if breakpoints.index(bp) == 0:
                     # first breakpoint
                     choices = tuple(('col-{}-{}'.format(bp, i), units[i]) for i in range(1, 13))
-                    label = _("Default column width")
+                    label = _("Column width for {}").format(devices)
                     help_text = chose_help_text(
                         _("Number of column units for devices narrower than {} pixels."),
                         _("Number of column units for devices wider than {} pixels."),
@@ -252,6 +252,11 @@ class BootstrapColumnPlugin(BootstrapPluginBase):
                 )
                 glossary_fields.append(PartialFormField('{}-responsive-utils'.format(bp),
                     widgets.RadioSelect(choices=choices), label=label, help_text=help_text, initial=''))
+        glossary_fields = [
+            glossary_fields[i + len(breakpoints) * j]
+            for i in range(0, 3)
+            for j in range(0, len(glossary_fields) / len(breakpoints))
+        ]
         kwargs.update(glossary_fields=glossary_fields)
         return super(BootstrapColumnPlugin, self).get_form(request, obj, **kwargs)
 


### PR DESCRIPTION
This little PR reorders glossary fields for Column Plugin so that fields are grouped by property rather then by breaking point. I find it much easier to configure Columns this way. It's purely a visual thing.

The objective rationale behind this PR is that a large majority of Columns have only their widths configured, leaving the other properties as default (offset, reorder and visibility).

![screen shot 2015-07-18 at 15 49 01](https://cloud.githubusercontent.com/assets/1173748/8761889/6e261688-2d68-11e5-961f-69a52e38abb3.png)
