### PR TITLE
Fix : close others settings not working on accordion panel

### DIFF
--- a/cmsplugin_cascade/bootstrap3/image.py
+++ b/cmsplugin_cascade/bootstrap3/image.py
@@ -48,7 +48,7 @@ class BootstrapImagePlugin(LinkPluginBase):
     name = _("Image")
     model_mixins = (ImagePropertyMixin, LinkElementMixin,)
     module = 'Bootstrap'
-    parent_classes = ['BootstrapColumnPlugin']
+    parent_classes = ['BootstrapColumnPlugin','BootstrapPanelPlugin']
     require_parent = True
     allow_children = False
     raw_id_fields = ('image_file',)

--- a/cmsplugin_cascade/bootstrap3/picture.py
+++ b/cmsplugin_cascade/bootstrap3/picture.py
@@ -20,7 +20,7 @@ class BootstrapPicturePlugin(LinkPluginBase):
     name = _("Picture")
     model_mixins = (ImagePropertyMixin, LinkElementMixin,)
     module = 'Bootstrap'
-    parent_classes = ['BootstrapColumnPlugin']
+    parent_classes = ['BootstrapColumnPlugin','BootstrapPanelPlugin']
     require_parent = True
     allow_children = False
     raw_id_fields = ('image_file',)

--- a/cmsplugin_cascade/templates/cascade/bootstrap3/accordion.html
+++ b/cmsplugin_cascade/templates/cascade/bootstrap3/accordion.html
@@ -9,7 +9,13 @@
 	<div class="panel {{ panel_type }}">
 		<div class="panel-heading">
 			{% if heading_size %}<{{ heading_size }} class="panel-title">{% endif %}
-				<a data-toggle="collapse" data-parent="#cmsplugin_{{ instance.id }}" href="#cmsplugin_{{ instance.id }}_{{ forloop.counter0 }}">{{ panel_title }}</a>
+				<a data-toggle="collapse" 
+					{% if instance.glossary.close_others = "on" %}
+						data-parent="#cmsplugin_{{ instance.id }}"
+					{% else %}
+						data-target="#cmsplugin_{{ instance.id }}_{{ forloop.counter0}}"
+					{% endif %}
+					href="#cmsplugin_{{ instance.id }}_{{ forloop.counter0 }}">{{ panel_title }}</a>
 			{% if heading_size %}</{{ heading_size }}>{% endif %}
 		</div>
 		<div id="cmsplugin_{{ instance.id }}_{{ forloop.counter0 }}" class="panel-collapse collapse{% if forloop.first  and instance.glossary.first_is_open = "on" %} in{% endif %}">


### PR DESCRIPTION
* was working with angular templates, but not with classic ones (it was always « one at a time » behavior, regardless of setting used)
* fixed by this patch