### PR TITLE
Documentation Update for bootstrap3_tags and main_menu

### DIFF
--- a/docs/source/bootstrap3/navbar.rst
+++ b/docs/source/bootstrap3/navbar.rst
@@ -4,6 +4,13 @@
 Template tag for the Bootstrap3 Navbar
 ======================================
 
+
+.. warning:: This template tag is now deprecated. It's functionality has been
+             split off into a new project that can be found here: 
+             `Django CMS Bootstrap 3`_.
+
+.. _Django CMS Bootstrap 3: https://github.com/jrief/djangocms-bootstrap3
+
 Although it's not derived from the ``CascadeElement`` class, this Django app is shipped with a
 template tag to render the main menu inside a `Bootstrap Navbar`_. This tag is named ``main_menu``
 and shall be used instead of ``show_menu``, as shipped with the DjangoCMS menu app.


### PR DESCRIPTION
load bootstrap_tags and {% main_menu %} template tags have been removed and placed into a separate repo, however the documentation does not reflect this. I added a warning to the top of the [navbar docs](http://djangocms-cascade.readthedocs.org/en/latest/bootstrap3/navbar.html) that provides a brief explanation as well as a link to the new repo. I believe the current documentation should stay in place since the new project does not provide any documentation at all.

I may have time to write up some documentation for the new project tomorrow.