### PR TITLE
Fixed issue #104 by removing version pinning for django-cms

### DIFF
--- a/examples/bs3demo/requirements.txt
+++ b/examples/bs3demo/requirements.txt
@@ -5,7 +5,7 @@ South
 argparse
 beautifulsoup4
 django-classy-tags
-django-cms==3.0.13
+django-cms
 django-filer
 django-mptt
 django-polymorphic


### PR DESCRIPTION
The pinned django-cms version is not compatible with current django-version (stable). Therefore a default installation installed stable django with an incompatible, outdated version of django-cms