### PR TITLE
Mark_safe causing JS error in TextLinkPlugin

### DIFF
--- a/cmsplugin_cascade/link/plugin_base.py
+++ b/cmsplugin_cascade/link/plugin_base.py
@@ -4,7 +4,6 @@ from django.db.models import get_model
 from django.forms import widgets
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
-from django.utils.safestring import mark_safe
 from cmsplugin_cascade.fields import PartialFormField
 from cmsplugin_cascade.plugin_base import CascadePluginBase
 from .forms import LinkForm
@@ -79,4 +78,4 @@ class LinkElementMixin(object):
 
     @property
     def content(self):
-        return mark_safe(self.glossary.get('link_content', ''))
+        return self.glossary.get('link_content', '')


### PR DESCRIPTION
If `link_content` contains a quote, it causes an error on javascript execution.
If we remove `mark_safe`, there are no error, but CKEDITOR displays `&#39;`: is this a bug in djangocms-text-ckeditor?