### PR TITLE
Update tox/travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ python:
 
 env:
   matrix:
-  - DJANGO='django18' CMS='cms31'
-  - DJANGO='django18' CMS='cms32'
-  - DJANGO='django19' CMS='cms32'
+  - PYVER='PY27' DJANGO='django18' CMS='cms32'
+  - PYVER='PY34' DJANGO='django18' CMS='cms32'
+  - PYVER='PY27' DJANGO='django19' CMS='cms32'
+  - PYVER='PY34' DJANGO='django19' CMS='cms32'
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = coverage-clean, py{27,34}-django{18,19}-cms{31,32}, coverage-report
+envlist = coverage-clean, py{27,34}-django{18,19}-cms{32}, coverage-report
 
 [testenv]
 # usedevelop is needed to collect coverage data
@@ -14,6 +14,8 @@ deps =
     py27: wsgiref
     -rtest_requirements.txt
     https://github.com/nephila/djangocms-helper/archive/develop.zip
+    django18: Django==1.8.8
+    django19: Django==1.9.1
 
 [testenv:coverage-clean]
 deps =


### PR DESCRIPTION
We now test Python 2.7 and 3.4, Django 1.8.8 and 1.9.1, and CMS 3.2.