### PR TITLE
Update version of django-reversion and fix import statement

### DIFF
--- a/cmsplugin_cascade/plugin_base.py
+++ b/cmsplugin_cascade/plugin_base.py
@@ -67,9 +67,9 @@ class CascadePluginBaseMetaclass(CMSPluginBaseMetaclass):
             model_mixins += tuple(import_string(mc[0]) for mc in settings.CMSPLUGIN_CASCADE['segmentation_mixins'])
         attrs['model'] = create_proxy_model(name, model_mixins, base_model)
         if is_installed('reversion'):
-            import reversion
-            if not reversion.is_registered(base_model):
-                reversion.register(base_model)
+            from reversion import revisions
+            if not revisions.is_registered(base_model):
+                revisions.register(base_model)
         # handle ambiguous plugin names by appending a symbol
         if 'name' in attrs and settings.CMSPLUGIN_CASCADE['plugin_prefix']:
             attrs['name'] = mark_safe_lazy(string_concat(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -20,4 +20,4 @@ pytest-django==2.9.1
 six==1.10.0
 tox==2.2.1
 virtualenv==13.1.2
-django-reversion==1.9.3
+django-reversion==1.10.1


### PR DESCRIPTION
The snippet which is needed to get djangocms-cascade running with the current version of django-reversion. Unfortunately I do not know how to run the tests of this project, so I am not sure that I did not break something through that change.