### PR TITLE
use breakpoints from settings in container plugin

### DIFF
--- a/cmsplugin_cascade/bootstrap3/carousel.py
+++ b/cmsplugin_cascade/bootstrap3/carousel.py
@@ -43,6 +43,11 @@ class CarouselPlugin(BootstrapPluginBase):
     fields = ('num_children', 'glossary',)
     DEFAULT_CAROUSEL_ATTRIBUTES = {'data-ride': 'carousel'}
     OPTION_CHOICES = (('slide', _("Animate")), ('pause', _("Pause")), ('wrap', _("Wrap")),)
+    initial_heights = dict()
+    i = 0
+    for bp in settings.CMSPLUGIN_CASCADE['bootstrap3']['breakpoints']:
+        initial_heights[bp[0]] = '{}px'.format(100 + (50 * i))
+        i += 1
     glossary_fields = (
         PartialFormField('interval',
             NumberInputWidget(attrs={'size': '2', 'style': 'width: 4em;', 'min': '1'}),
@@ -60,7 +65,7 @@ class CarouselPlugin(BootstrapPluginBase):
             MultipleCascadingSizeWidget(list(tp[0] for tp in settings.CMSPLUGIN_CASCADE['bootstrap3']['breakpoints']),
             allowed_units=['px']),
             label=_("Carousel heights"),
-            initial={'xs': '100px', 'sm': '150px', 'md': '200px', 'lg': '300px'},
+            initial=initial_heights,
             help_text=_("Heights of Carousel in pixels for distinct Bootstrap's breakpoints."),
         ),
         PartialFormField('resize-options',

--- a/cmsplugin_cascade/bootstrap3/container.py
+++ b/cmsplugin_cascade/bootstrap3/container.py
@@ -48,17 +48,17 @@ class BootstrapContainerPlugin(BootstrapPluginBase):
     form = BootstrapContainerForm
     breakpoints = list(BS3_BREAKPOINTS)
     i = 0
-    widget_choises = []
+    widget_choices = []
     for br, br_options in BS3_BREAKPOINTS.items():
         if i == 0:
-            widget_choises.append((br, '{} (<{}px)'.format(br_options[2], br_options[0])))
+            widget_choices.append((br, '{} (<{}px)'.format(br_options[2], br_options[0])))
         elif i == len(breakpoints[:-1]):
-            widget_choises.append((br, '{} (≥{}px)'.format(br_options[2], br_options[0])))
+            widget_choices.append((br, '{} (≥{}px)'.format(br_options[2], br_options[0])))
         else:
-            widget_choises.append((br, '{} (≥{}px and <{}px)'.format(br_options[2], br_options[0], BS3_BREAKPOINTS[breakpoints[(i + 1)]][0])))
+            widget_choices.append((br, '{} (≥{}px and <{}px)'.format(br_options[2], br_options[0], BS3_BREAKPOINTS[breakpoints[(i + 1)]][0])))
         i += 1
 
-    WIDGET_CHOICES = tuple(widget_choises)
+    WIDGET_CHOICES = tuple(widget_choices)
 
     glossary_fields = (
         PartialFormField('breakpoints',


### PR DESCRIPTION
Hi!
Here is my proposal. for issue #131 
Keep in mind that i'm new to python, so most likely the additions i propose could be rewritten in a more pythonic way. If so please feel free to either do it or advice me about it :)

The "only" issue i've bumped into is that if i create elements using some breakpoints, and then i REMOVE the br from the settings, then it breaks. (the element glossary is still having them stored, but i'm not sure how to proceed in this sense).

As a side note, i Have NOT touched the documentation, as I'm not sure if you'd like me to do it, or if you'd rather have control over it. Either way, let me know so i can gladly update it as well.