### PR TITLE
Add missing migration

### DIFF
--- a/cmsplugin_cascade/migrations/0006_bootstrapgallerypluginmodel.py
+++ b/cmsplugin_cascade/migrations/0006_bootstrapgallerypluginmodel.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_cascade', '0005_tabset_and_clipboard'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BootstrapGalleryPluginModel',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('cmsplugin_cascade.cascadeelement',),
+        ),
+    ]


### PR DESCRIPTION
I think we should include this migration (for the gallery plugin), but I am not entirely sure :)

For some reason, `manage.py runserver` does not complain about the fact that this migration is missing (does anyone know why?), but `manage.py makemigrations` creates it.