### PR TITLE
Remove wsgiref

### DIFF
--- a/docs/source/impatient.rst
+++ b/docs/source/impatient.rst
@@ -50,7 +50,6 @@ Create a temporary file, for instance named requirements.txt, containing these e
 	html5lib==0.9999999
 	jsonfield==1.0.3
 	six==1.9.0
-	wsgiref==0.1.2
 
 and install them into your environment:
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands =
     coverage run -a {envbindir}/py.test tests
 deps =
     -rtest_requirements.txt
-    py27: wsgiref==0.1.2
     djangocms-helper==0.9.4
     coverage==4.0.2
     cms32: django-cms==3.2.1


### PR DESCRIPTION
The wsgiref package should only be used on ancient Python versions that we do
not support anyway (2.4).