### PR TITLE
Conditional import of "low level api" from reversion app

### DIFF
--- a/cmsplugin_cascade/plugin_base.py
+++ b/cmsplugin_cascade/plugin_base.py
@@ -71,7 +71,11 @@ class CascadePluginBaseMetaclass(CMSPluginBaseMetaclass):
         app_label = attrs.get('app_label', module.split('.')[0])
         attrs['model'] = create_proxy_model(name, app_label, model_mixins, base_model, module=module)
         if is_installed('reversion'):
-            import reversion
+            from reversion import VERSION as reversion_VERSION
+            if reversion_VERSION < (1, 10):
+                import reversion
+            else:
+                from reversion import revisions as reversion
             if not reversion.is_registered(base_model):
                 reversion.register(base_model)
         # handle ambiguous plugin names by appending a symbol


### PR DESCRIPTION
Importing the "low level API" from `reversions` app has changed in version 1.10, according to the docs:
http://django-reversion.readthedocs.org/en/latest/api.html#importing-the-low-level-api

Without this fix `./manage.py check` raises:

    ...
      File "/Volumes/Projects/spire/spire_site/cmsplugin_cascade/plugin_base.py", line 78, in __new__
        if not reversion.is_registered(base_model):
    AttributeError: 'module' object has no attribute 'is_registered'

