### PR TITLE
offset options that allow "0"

### DIFF
--- a/cmsplugin_cascade/bootstrap3/container.py
+++ b/cmsplugin_cascade/bootstrap3/container.py
@@ -240,8 +240,15 @@ class BootstrapColumnPlugin(BootstrapPluginBase):
                         initial='', label=label, help_text=help_text))
 
                 # handle offset
-                choices = (('', _("No offset")),) + \
-                    tuple(('col-{}-offset-{}'.format(bp, i), units[i]) for i in range(1, 12))
+                if breakpoints.index(bp) == 0:
+                    empty_offset_choice = _("No offset")
+                    offset_range = range(1, 12)
+                else:
+                    empty_offset_choice = _("Inherit from above")
+                    offset_range = range(0, 12)
+                choices = (('', empty_offset_choice),) + \
+                    tuple(('col-{}-offset-{}'.format(bp, i), units[i])
+                          for i in offset_range)
                 label = _("Offset for {}").format(devices)
                 help_text = chose_help_text(
                     _("Number of offset units for devices narrower than {} pixels."),

--- a/cmsplugin_cascade/bootstrap3/container.py
+++ b/cmsplugin_cascade/bootstrap3/container.py
@@ -242,10 +242,10 @@ class BootstrapColumnPlugin(BootstrapPluginBase):
                 # handle offset
                 if breakpoints.index(bp) == 0:
                     empty_offset_choice = _("No offset")
-                    offset_range = range(1, 12)
+                    offset_range = range(1, 13)
                 else:
                     empty_offset_choice = _("Inherit from above")
-                    offset_range = range(0, 12)
+                    offset_range = range(0, 13)
                 choices = (('', empty_offset_choice),) + \
                     tuple(('col-{}-offset-{}'.format(bp, i), units[i])
                           for i in offset_range)


### PR DESCRIPTION
Offset options needed fixing. 

This is a perfectly viable combination of classes: `col-xs-offset-2 col-sm-offset-0`. This PR makes it possible.

Also, offset is inherited ("mobile first") just like widths, so "No offset" option was misleading.