### PR TITLE
CSS does not allow space between value and units

### DIFF
--- a/cmsplugin_cascade/widgets.py
+++ b/cmsplugin_cascade/widgets.py
@@ -103,7 +103,7 @@ def _compile_validation_pattern(widget, units):
             raise ValidationError('{0} is not a valid unit for CascadingSizeField'.format(u))
     endings = (' %s ' % ugettext("or")).join("'%s'" % u.replace('%', '%%') for u in units)
     params = {'label': '%(label)s', 'value': '%(value)s', 'field': '%(field)s', 'endings': endings}
-    return re.compile(r'^(-?\d+)\s*({0})$'.format('|'.join(units))), widget.invalid_message % params
+    return re.compile(r'^(-?\d+)({0})$'.format('|'.join(units))), widget.invalid_message % params
 
 
 class CascadingSizeWidget(widgets.TextInput):


### PR DESCRIPTION
... so neither should extra_fields.

This currently passes as a valid margin value:

![screen shot 2016-03-25 at 05 58 35](https://cloud.githubusercontent.com/assets/1173748/14038283/d31b7938-f24e-11e5-947f-f08a975b7aac.png)

... but of course, is not:
![screen shot 2016-03-25 at 05 58 17](https://cloud.githubusercontent.com/assets/1173748/14038300/f64d7514-f24e-11e5-9dd1-0cc68cce6d1e.png)

This PR removes optional space from the regex that checks validity.

The only usages I could find (two of them) are using this function with `['px', 'em', '%']` units, apparently for CSS.

