### PR TITLE
Fixed database migration failing on multiple database setup

### DIFF
--- a/cmsplugin_cascade/migrations/0010_refactor_heading.py
+++ b/cmsplugin_cascade/migrations/0010_refactor_heading.py
@@ -6,7 +6,7 @@ from django.db import migrations
 
 def forwards(apps, schema_editor):
     CascadeElement = apps.get_model('cmsplugin_cascade', 'CascadeElement')
-    for element in CascadeElement.objects.filter(plugin_type='HeadingPlugin'):
+    for element in CascadeElement.objects.using(schema_editor.connection.alias).filter(plugin_type='HeadingPlugin'):
         head_size = element.glossary.pop('head_size', None)
         if head_size:
             element.glossary['tag_type'] = 'h{}'.format(head_size)
@@ -15,7 +15,7 @@ def forwards(apps, schema_editor):
 
 def backwards(apps, schema_editor):
     CascadeElement = apps.get_model('cmsplugin_cascade', 'CascadeElement')
-    for element in CascadeElement.objects.filter(plugin_type='HeadingPlugin'):
+    for element in CascadeElement.objects.using(schema_editor.connection.alias).filter(plugin_type='HeadingPlugin'):
         tag_type = element.glossary.pop('tag_type', None)
         if tag_type and len(tag_type) == 2:
             element.glossary['head_size'] = tag_type[1]


### PR DESCRIPTION
When having a database setup like the following, the ``manage.py migrate`` command fails with an error.
```python
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.sqlite3',
        'HOST': 'localhost',
        'NAME': 'project.db'
    },
    'slave': {
        'ENGINE': 'django.db.backends.sqlite3',
        'HOST': 'localhost',
        'NAME': 'project.db.slave',
        'TEST': {
            'MIRROR': 'default'
        }
    }
}
```

This PR fixes the issue.
