### PR TITLE
Remove FontIconPlugin from default `plugins_with_sharables` setting

### DIFF
--- a/cmsplugin_cascade/settings.py
+++ b/cmsplugin_cascade/settings.py
@@ -69,12 +69,7 @@ With 'plugins_with_extra_fields' we can specify a set of plugins eligible for ac
 styles.
 """
 
-if 'cmsplugin_cascade.sharable' in settings.INSTALLED_APPS:
-    CMSPLUGIN_CASCADE.setdefault('plugins_with_sharables', {})
-else:
-    CMSPLUGIN_CASCADE['plugins_with_sharables'] = {
-        'FontIconPlugin': ('font-size', 'color', 'text-align', 'border', 'border-radius'),
-    }
+CMSPLUGIN_CASCADE.setdefault('plugins_with_sharables', {})
 
 CMSPLUGIN_CASCADE.setdefault('link_plugin_classes', (
     'cmsplugin_cascade.link.plugin_base.DefaultLinkPluginBase',


### PR DESCRIPTION
Fix [#444](https://github.com/awesto/django-shop/issues/444) from djangoSHOP.