### PR TITLE
SegmentPlugin.get_form OrderedDict value lookups now compatible with python3

### DIFF
--- a/cmsplugin_cascade/segmentation/cms_plugins.py
+++ b/cmsplugin_cascade/segmentation/cms_plugins.py
@@ -132,8 +132,8 @@ class SegmentPlugin(TransparentMixin, CascadePluginBase):
                 raise ValidationError(_("Unable to evaluate condition: {err}").format(err=err.message))
 
         choices = self.get_allowed_open_tags(obj)
-        self.glossary_fields[0].widget.choices = choices
-        self.glossary_fields[1].widget.validate = clean_condition
+        list(self.glossary_fields)[0].widget.choices = choices
+        list(self.glossary_fields)[1].widget.validate = clean_condition
         # remove escape quotes, added by JSON serializer
         if obj:
             condition = self.html_parser.unescape(obj.glossary.get('condition', ''))


### PR DESCRIPTION
When using cms-cascade with Python 3.5, the `SegmentPlugin.get_form` call fails due to return type changes in `OrderedDict.values`, which does not return a list anymore but instead an odict_values object. This object does not support index lookups anymore and thus needs to be converted to a list before accessing its items by index.