### PR TITLE
Use TextPlugin as a child for carousel without losing the existing usage of it between django cms ckeditor 3.0.1 and 3.3.1

### DIFF
--- a/cmsplugin_cascade/templates/cascade/bootstrap3/carousel-slide.html
+++ b/cmsplugin_cascade/templates/cascade/bootstrap3/carousel-slide.html
@@ -1,6 +1,17 @@
+{% load cms_tags %}
 {% include "cascade/bootstrap3/picture.html" %}
 {% if caption %}
 <div class="carousel-caption">
 	{{ caption|safe }}
 </div>
+{% else %}
+	{% for plugin in instance.child_plugin_instances %}
+		{% if forloop.first %}
+			<div class="carousel-caption">
+		{% endif %}
+		{% render_plugin plugin %}
+		{% if forloop.last %}
+			</div>
+		{% endif %}
+	{% endfor %}
 {% endif %}


### PR DESCRIPTION
Use TextPlugin as a child for carousel without losing the existing usage of it between django cms ckeditor 3.0.1 and 3.3.1