### PR TITLE
Add a test for missing migrations.

### DIFF
--- a/tests/test_missingmigrations.py
+++ b/tests/test_missingmigrations.py
@@ -1,0 +1,14 @@
+import cStringIO
+
+from django.test import TestCase
+from django.core.management import call_command
+
+
+class MissingMigrationTest(TestCase):
+
+    def test_for_missing_migrations(self):
+        out = cStringIO.StringIO()
+
+        call_command('makemigrations', '--dry-run',
+                     verbocity=3, interactive=False, stdout=out)
+        self.assertEquals(out.getvalue(), 'No changes detected\n')


### PR DESCRIPTION
This commit detects missing migrations by running makemigrations
with the --dry-run flag and checking for the 'No changes detected'
message on stdout.  Otherwise, the error includes information on
the migrations that are missing.