### PR TITLE
Add Icon to TextLinkPlugin

### DIFF
--- a/cmsplugin_cascade/link/cms_plugins.py
+++ b/cmsplugin_cascade/link/cms_plugins.py
@@ -1,15 +1,71 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
+from django.forms import widgets
 from django.forms.fields import CharField
 from django.forms.widgets import TextInput
+from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
 
+from cmsplugin_cascade.fields import GlossaryField
 from cms.plugin_pool import plugin_pool
 
 from .config import LinkPluginBase, LinkElementMixin, LinkForm
 from .forms import TextLinkFormMixin
+
+if 'cmsplugin_cascade.icon' in settings.INSTALLED_APPS:
+    from cmsplugin_cascade.icon.mixins import IconPluginMixin
+else:
+    from cmsplugin_cascade.plugin_base import CascadePluginMixinBase as IconPluginMixin
+
+
+class TextLinkIconMixin(IconPluginMixin):
+    require_parent = True
+    parent_classes = ('BootstrapColumnPlugin', 'SimpleWrapperPlugin',)
+    render_template = 'cascade/link/text-link.html'
+    allow_children = False
+    ring_plugin = 'ButtonMixin'
+
+    icon_align = GlossaryField(
+        widgets.RadioSelect(choices=(('', _("No Icon")), ('icon-left', _("Icon placed left")),
+                                     ('icon-right', _("Icon placed right")),)),
+        label=_("Icon alignment"),
+        initial='',
+        help_text=_("Add an Icon before or after the button content.")
+    )
+
+    icon_font = GlossaryField(
+        widgets.Select(),
+        label=_("Font"),
+    )
+
+    symbol = GlossaryField(
+        widgets.HiddenInput(),
+        label=_("Select Symbol"),
+    )
+
+    class Media:
+        js = ['cascade/js/admin/buttonmixin.js']
+
+    def render(self, context, instance, placeholder):
+        context = super(TextLinkIconMixin, self).render(context, instance, placeholder)
+        try:
+            icon_font = self.get_icon_font(instance)
+            symbol = instance.glossary.get('symbol')
+        except AttributeError:
+            icon_font, symbol = None, None
+        if icon_font and symbol:
+            context['stylesheet_url'] = icon_font.get_stylesheet_url()
+            mini_template = '{0}<i class="icon-{1} {2}" aria-hidden="true"></i>{3}'
+            icon_align = instance.glossary.get('icon_align')
+            if icon_align == 'icon-left':
+                context['icon_left'] = format_html(mini_template, '', symbol, 'cascade-icon-left', ' ')
+            elif icon_align == 'icon-right':
+                context['icon_right'] = format_html(mini_template, ' ', symbol, 'cascade-icon-right', '')
+            print(context)
+        return context
 
 
 class TextLinkPlugin(LinkPluginBase):

--- a/cmsplugin_cascade/templates/cascade/link/text-link.html
+++ b/cmsplugin_cascade/templates/cascade/link/text-link.html
@@ -1,1 +1,5 @@
-{% with instance_css_classes=instance.css_classes instance_inline_styles=instance.inline_styles %}<a href="{{ instance.link }}" {{ instance.html_tag_attributes }}{% if instance_css_classes %} class="{{ instance_css_classes }}"{% endif %}{% if instance_inline_styles %} style="{{ instance_inline_styles }}"{% endif %}>{% block link_content %}{{ instance.content }}{% endblock %}</a>{% endwith %}
+{% load sekizai_tags %}
+{% if stylesheet_url %}{% addtoblock "css" %}<link href="{{ stylesheet_url }}" rel="stylesheet" type="text/css" />{% endaddtoblock %}{% endif %}
+{% spaceless %}
+{% with instance_css_classes=instance.css_classes instance_inline_styles=instance.inline_styles %}<a href="{{ instance.link }}" {{ instance.html_tag_attributes }}{% if instance_css_classes %} class="{{ instance_css_classes }}"{% endif %}{% if instance_inline_styles %} style="{{ instance_inline_styles }}"{% endif %}>{% block link_content %}{{ icon_left }}{{ instance.content }}{{ icon_right }}{% endblock %}</a>{% endwith %}
+{% endspaceless %}


### PR DESCRIPTION
This allows you to add an icon with a clickable link in TextLinkPlugin.
Is this feature right for you?

This uses the button ring (buttonmixin.js) which also fits for this purpose. Should we rename it or create a new file or leave it like that?
Maybe it will be necessary that I create a mixin because it makes small repetitions with the plugin Button. if so, a mixin in the file "cmplugin_cascade plugin_base.py"?
