### PR TITLE
Fix compatibility issue with cms 3.5

### DIFF
--- a/cmsplugin_cascade/templatetags/cascade_tags.py
+++ b/cmsplugin_cascade/templatetags/cascade_tags.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 import io
 import json
 import os
+from distutils.version import LooseVersion
 
+from cms import __version__ as cms_version
 from cms.toolbar.utils import get_toolbar_from_request
 from django import template
 from django.conf import settings
@@ -17,6 +19,7 @@ from classytags.arguments import Argument
 from classytags.core import Options, Tag
 
 register = template.Library()
+CMS_LT_3_5 = LooseVersion(cms_version) < LooseVersion('3.5')
 
 
 class StrideRenderer(Tag):
@@ -71,14 +74,14 @@ class RenderPlugin(Tag):
         if not plugin:
             return ''
 
-        try:
+        if CMS_LT_3_5:
             content_renderer = context['cms_content_renderer']
             content = content_renderer.render_plugin(
                 instance=plugin,
                 context=context,
                 editable=content_renderer.user_is_on_edit_mode(),
             )
-        except KeyError:
+        else:
             toolbar = get_toolbar_from_request(context['request'])
             content_renderer = toolbar.content_renderer
             content = content_renderer.render_plugin(

--- a/cmsplugin_cascade/templatetags/cascade_tags.py
+++ b/cmsplugin_cascade/templatetags/cascade_tags.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 
+from cms.toolbar.utils import get_toolbar_from_request
 from django import template
 from django.conf import settings
 from django.core.cache import caches
@@ -70,12 +71,21 @@ class RenderPlugin(Tag):
         if not plugin:
             return ''
 
-        content_renderer = context['cms_content_renderer']
-        content = content_renderer.render_plugin(
-            instance=plugin,
-            context=context,
-            editable=content_renderer.user_is_on_edit_mode(),
-        )
+        try:
+            content_renderer = context['cms_content_renderer']
+            content = content_renderer.render_plugin(
+                instance=plugin,
+                context=context,
+                editable=content_renderer.user_is_on_edit_mode(),
+            )
+        except KeyError:
+            toolbar = get_toolbar_from_request(context['request'])
+            content_renderer = toolbar.content_renderer
+            content = content_renderer.render_plugin(
+                instance=plugin,
+                context=context,
+                editable=toolbar.edit_mode_active,
+            )
         return content
 
 register.tag('render_plugin', RenderPlugin)


### PR DESCRIPTION
In cms 3.5, The ‘cms_content_renderer’ is no more added to the context in cms.context_processors.cms_settings, generating a KeyError in cascade_tags when rendering for example TexEditorPlugin.