### PR TITLE
fix #279 Skin mono no longer available

### DIFF
--- a/examples/bs3demo/settings.py
+++ b/examples/bs3demo/settings.py
@@ -253,7 +253,6 @@ CMS_PLACEHOLDER_CONF = {
 
 CKEDITOR_SETTINGS = {
     'language': '{{ language }}',
-    'skin': 'moono',
     'toolbar': 'CMS',
     'stylesSet': format_lazy('default:{}', reverse_lazy('admin:cascade_texticon_wysiwig_config')),
 }


### PR DESCRIPTION
Skin mono is no longer available and no longer needed for version of djangocms_text_ckeditor==3.5.3, and that does not interfere with the previous version of djangocms_text_ckeditor.