### PR TITLE
Fix font-size icon don't work without text_align

### DIFF
--- a/cmsplugin_cascade/icon/cms_plugins.py
+++ b/cmsplugin_cascade/icon/cms_plugins.py
@@ -85,7 +85,7 @@ class FramedIconPlugin(IconPluginMixin, CascadePluginBase):
 
     @classmethod
     def get_tag_type(self, instance):
-        if instance.glossary.get('text_align'):
+        if instance.glossary.get('text_align') or instance.glossary.get('font_size'):
             return 'div'
 
     @classmethod


### PR DESCRIPTION
Without text_align, tag_type is None and so the style font-size was not applied.