### PR TITLE
ColorPickerWidget with alpha use variable environ instead of settings variable

### DIFF
--- a/cmsplugin_cascade/widgets.py
+++ b/cmsplugin_cascade/widgets.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import os
 import re
 import json
 try:

--- a/cmsplugin_cascade/widgets.py
+++ b/cmsplugin_cascade/widgets.py
@@ -160,7 +160,7 @@ class ColorPickerWidget(widgets.MultiWidget):
     DEFAULT_ATTRS = {'style': 'width: 11em; padding-left: 26px;', 'type': 'text'}
     validation_pattern = re.compile('(#(?:[0-9a-fA-F]{2}){2,4}|(#[0-9a-fA-F]{3})|(rgb|hsl)a?\((-?\d+%?[,\s]+){2,3}\s*[\d\.]+%?\))')
     invalid_message = _("In '%(label)s': Value '%(value)s' is not a valid color.")
-    JS_COLOR_PICKER_WITH_ALPHA= os.environ.get('JS_COLOR_PICKER_WITH_ALPHA', True)
+    JS_COLOR_PICKER_WITH_ALPHA = os.environ.get('JS_COLOR_PICKER_WITH_ALPHA', True)
     
     if JS_COLOR_PICKER_WITH_ALPHA:
         class Media:

--- a/cmsplugin_cascade/widgets.py
+++ b/cmsplugin_cascade/widgets.py
@@ -159,9 +159,8 @@ class ColorPickerWidget(widgets.MultiWidget):
     DEFAULT_ATTRS = {'style': 'width: 11em; padding-left: 26px;', 'type': 'text'}
     validation_pattern = re.compile('(#(?:[0-9a-fA-F]{2}){2,4}|(#[0-9a-fA-F]{3})|(rgb|hsl)a?\((-?\d+%?[,\s]+){2,3}\s*[\d\.]+%?\))')
     invalid_message = _("In '%(label)s': Value '%(value)s' is not a valid color.")
-    from django.conf import settings
-    JS_COLOR_PICKER_WITH_ALPHA= True if hasattr(settings, 'COLOR_PICKER_WITH_ALPHA') and settings.COLOR_PICKER_WITH_ALPHA == True else False
-
+    JS_COLOR_PICKER_WITH_ALPHA= os.environ.get('JS_COLOR_PICKER_WITH_ALPHA', True)
+    
     if JS_COLOR_PICKER_WITH_ALPHA:
         class Media:
             js = ['cascade/js/admin/colorpickerext.js' ]


### PR DESCRIPTION
When trying to import `ColorPickerWidget` in `BootstrapUtilities`  property it did not work, there was this error:

`
django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.`