### PR TITLE
Fix: In the page, TextPlugin does not have all ckeditor style classes

### DIFF
--- a/cmsplugin_cascade/static/cascade/scss/variables_BS4.scss
+++ b/cmsplugin_cascade/static/cascade/scss/variables_BS4.scss
@@ -1,0 +1,20 @@
+//text ckeditor and bootstrap4
+.italique {
+	@extend .font-italic;
+}
+
+blockquote
+{
+	font-style: italic;
+	font-family: Georgia, Times, "Times New Roman", serif;
+	padding: 2px 0;
+	border-style: solid;
+	border-color: #ccc;
+	border-width: 0;
+}
+
+//use bootstrap4 blockquote
+//blockquote {
+//    @extend .blockquote;
+//}
+

--- a/cmsplugin_cascade/static/cascade/scss/variables_BS4.scss
+++ b/cmsplugin_cascade/static/cascade/scss/variables_BS4.scss
@@ -1,8 +1,4 @@
 //text ckeditor and bootstrap4
-.italique {
-	@extend .font-italic;
-}
-
 blockquote p{
     margin-top: 1rem;
     margin-bottom: 1rem;
@@ -21,9 +17,3 @@ blockquote
 	border-left-width: 5px;
 	margin: 0px !important;
 }
-
-//use bootstrap4 blockquote
-//blockquote {
-//    @extend .blockquote;
-//}
-

--- a/cmsplugin_cascade/static/cascade/scss/variables_BS4.scss
+++ b/cmsplugin_cascade/static/cascade/scss/variables_BS4.scss
@@ -3,14 +3,23 @@
 	@extend .font-italic;
 }
 
+blockquote p{
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+
 blockquote
 {
 	font-style: italic;
 	font-family: Georgia, Times, "Times New Roman", serif;
-	padding: 2px 0;
+	padding: 2px 2px;
 	border-style: solid;
 	border-color: #ccc;
 	border-width: 0;
+	padding-left: 20px;
+	padding-right: 8px;
+	border-left-width: 5px;
+	margin: 0px !important;
 }
 
 //use bootstrap4 blockquote

--- a/examples/bs4demo/settings.py
+++ b/examples/bs4demo/settings.py
@@ -7,6 +7,7 @@ import sys
 from django.core.urlresolvers import reverse_lazy
 
 from cmsplugin_cascade.extra_fields.config import PluginExtraFieldsConfig
+from cmsplugin_cascade import __path__ as cmsplugin_cascade_path
 from django.utils.text import format_lazy
 
 DEBUG = True
@@ -284,6 +285,7 @@ THUMBNAIL_OPTIMIZE_COMMAND = {
 }
 
 SASS_PROCESSOR_INCLUDE_DIRS = [
+    os.path.join(cmsplugin_cascade_path[0] , 'static', ),
     os.path.join(PROJECT_ROOT, 'node_modules'),
 ]
 

--- a/examples/bs4demo/static/bs4demo/css/main.scss
+++ b/examples/bs4demo/static/bs4demo/css/main.scss
@@ -1,5 +1,6 @@
 @import "variables";
 @import "bootstrap/scss/bootstrap";
+@import "cascade/css/variables_BS4";
 @import "footer";
 
 body {


### PR DESCRIPTION
There is anothers ways to add the css classes of ckeditor but with this option we would have a specific scss file for django-cascade that could be used to use dynamic settings for some global bootstrap scss variables thanks to django-sass -processor.