### PR TITLE
Fix: KeyError if a Breakpoint is not checked in container plugin

### DIFF
--- a/cmsplugin_cascade/bootstrap4/grid.py
+++ b/cmsplugin_cascade/bootstrap4/grid.py
@@ -225,7 +225,8 @@ class Bootstrap4Row(list):
     def compute_column_bounds(self):
         assert isinstance(self.bounds, dict)
         for bp in [Breakpoint.xs, Breakpoint.sm, Breakpoint.md, Breakpoint.lg, Breakpoint.xl]:
-            remaining_width = copy(self.bounds[bp])
+            if bp in self.bounds:
+                remaining_width = copy(self.bounds[bp])
 
             # first compute the bounds of columns with a fixed width
             for column in self:


### PR DESCRIPTION
If a Breakpoint is not checked in container plugin and if there is a image / picture in a columns.
This is not necessary for the jumbotron apparently.