### PR TITLE
Jumbotronplugin add choices:  element_heights or auto

### DIFF
--- a/cmsplugin_cascade/bootstrap4/jumbotron.py
+++ b/cmsplugin_cascade/bootstrap4/jumbotron.py
@@ -19,10 +19,15 @@ logger = logging.getLogger('cascade')
 class ImageBackgroundMixin(object):
     @property
     def element_heights(self):
-        element_heights = self.glossary.get('element_heights', {})
-        for bp, media_query in self.glossary['media_queries'].items():
-            if bp in element_heights:
-                yield {'media': media_query['media'], 'height': element_heights[bp]}
+        try:
+            element_heights_choices = self.glossary.get('element_heights_choices', {})
+            if element_heights_choices == 'element heights':
+                element_heights = self.glossary.get('element_heights', {})
+                for bp, media_query in self.glossary['media_queries'].items():
+                    if bp in element_heights:
+                        yield {'media': media_query['media'], 'height': element_heights[bp]}
+        except (KeyError, TypeError, ValueError):
+            pass
 
     @property
     def background_color(self):
@@ -78,12 +83,22 @@ class JumbotronFormMixin(EntangledModelFormMixin):
     HORIZONTAL_POSITION_CHOICES = ['left', '10%', '20%', '30%', '40%', 'center', '60%', '70%', '80%', '90%', 'right']
     REPEAT_CHOICES = ['repeat', 'repeat-x', 'repeat-y', 'no-repeat']
     SIZE_CHOICES = ['auto', 'width/height', 'cover', 'contain']
+    ELEMENT_HEIGHT = ['element heights','auto']
 
     fluid = BooleanField(
         label=_("Is fluid"),
         initial=True,
         required=False,
         help_text=_("Shall this element occupy the entire horizontal space of its parent."),
+    )
+
+    element_heights_choices = ChoiceField(
+        label=_("Element heights choices"),
+        choices=[(c, c) for c in ELEMENT_HEIGHT],
+        widget=widgets.RadioSelect,
+        initial='element heights',
+        required=False,
+        help_text=_("This property specifies how the background image is sized."),
     )
 
     element_heights = BootstrapMultiSizeField(
@@ -155,7 +170,7 @@ class JumbotronFormMixin(EntangledModelFormMixin):
     )
 
     class Meta:
-        entangled_fields = {'glossary': ['fluid', 'background_color', 'element_heights', 'image_file',
+        entangled_fields = {'glossary': ['fluid', 'background_color', 'element_heights_choices', 'element_heights', 'image_file',
                                          'background_repeat', 'background_attachment',
                                          'background_vertical_position', 'background_horizontal_position',
                                          'background_size', 'background_width_height']}

--- a/cmsplugin_cascade/static/cascade/js/admin/jumbotronplugin.js
+++ b/cmsplugin_cascade/static/cascade/js/admin/jumbotronplugin.js
@@ -63,6 +63,7 @@ django.jQuery(function($) {
 		refreshChangeForm: function() {
 			this.fileIdInputChanged();
 			this.backgroundInputSizeChanged();
+			this.elementHeightsChoicesChanged();
 			this.$super && this.$super();
 		}
 

--- a/cmsplugin_cascade/static/cascade/js/admin/jumbotronplugin.js
+++ b/cmsplugin_cascade/static/cascade/js/admin/jumbotronplugin.js
@@ -3,9 +3,11 @@ django.jQuery(function($) {
 
 	// create class handling the client-side part of JumbotronPlugin
 	var base_plugins = eval(django.cascade.ring_plugin_bases.JumbotronPlugin),
-	    $fileIdInputSelector = $('#id_image_file'),
-	    $backgroundInputSize = $('input[name="background_size"]'),
-	    $backgroundWidthHeight = $('.form-row.field-background_width_height');
+		$fileIdInputSelector = $('#id_image_file'),
+		$backgroundInputSize = $('input[name="background_size"]'),
+		$backgroundWidthHeight = $('.form-row.field-background_width_height'),
+		$elementHeightsChoices = $('input[name="element_heights_choices"]'),
+		$elementHeights = $('.form-row.field-element_heights');
 
 	django.cascade.JumbotronPlugin = ring.create(base_plugins, {
 		constructor: function() {
@@ -17,7 +19,7 @@ django.jQuery(function($) {
 				window.setTimeout(self.fileIdInputChanged);
 			});
 			$backgroundInputSize.on('change', self.backgroundInputSizeChanged);
-
+			$elementHeightsChoices.on('change', self.elementHeightsChoicesChanged);
 			// set defaults
 			this.refreshChangeForm();
 		},
@@ -48,6 +50,14 @@ django.jQuery(function($) {
 				$backgroundWidthHeight.show();
 			} else {
 				$backgroundWidthHeight.hide();
+			}
+		},
+		elementHeightsChoicesChanged: function() {
+			var $inputField = $('input[name="element_heights_choices"]:checked');
+			if ($inputField.val() === 'element heights') {
+				$elementHeights.show();
+			} else {
+				$elementHeights.hide();
 			}
 		},
 		refreshChangeForm: function() {


### PR DESCRIPTION
This makes it possible to automatically adjust the height of the jumbotron, for example with a navbar that has a jumbotron parent:

![Peek 23-10-2019 10-02](https://user-images.githubusercontent.com/344493/67371965-7be78b80-f57d-11e9-9e17-51feae51716f.gif)
