### PR TITLE
fixed range did not include the last breakpoint.xl

### DIFF
--- a/cmsplugin_cascade/bootstrap4/container.py
+++ b/cmsplugin_cascade/bootstrap4/container.py
@@ -210,7 +210,7 @@ class BootstrapColumnPlugin(BootstrapPluginBase):
         units = [ungettext_lazy("{} unit", "{} units", i).format(i) for i in range(0, 13)]
         for bp in breakpoints:
             try:
-                last = getattr(grid.Breakpoint, breakpoints[breakpoints.index(bp) + 1])
+                last = getattr(grid.Breakpoint, breakpoints[breakpoints.index(bp)])
             except IndexError:
                 last = None
             finally:

--- a/cmsplugin_cascade/bootstrap4/grid.py
+++ b/cmsplugin_cascade/bootstrap4/grid.py
@@ -28,7 +28,7 @@ class Breakpoint(Enum):
     def range(cls, first, last):
         if first: first = first.value
         if last: last = last.value
-        return itertools.islice(cls, first, last)
+        return itertools.islice(cls, first, last+1)
 
     def __gt__(self, other):
         return self.value > other.value


### PR DESCRIPTION
Affected: 
BootstrapUtilities.paddings
BootstrapUtilities.margins
BootstrapUtilities.floats,
BootstrapUtilities.vertical_margins

Helpers:
https://stackoverflow.com/questions/4504662/why-does-rangestart-end-not-include-end