### PR TITLE
Sal (Scroll Animation Library) with CascadeUtilitiesMixin 

### DIFF
--- a/cmsplugin_cascade/bootstrap4/mixins.py
+++ b/cmsplugin_cascade/bootstrap4/mixins.py
@@ -23,26 +23,49 @@ class BootstrapUtilities(type):
         …
     }
     ```
-
     The class ``BootstrapUtilities`` offers a bunch of property methods which return a list of
     input fields and/or select boxes. They then can be added to the plugin's editor. This is
-    specially useful to add CSS classes from the utilities section of Bootstrap-4, such as
+    specially useful to add CSS classes or HTML data attributes from the utilities section of Bootstrap-4, such as
     margins, borders, colors, etc.
+    
+    The 'property_name' attritbute in property methods is needed because python property methods don't have name
+    attributes without using inspect module or others things. 
+    The 'attrs_type' attritbute in property methods can have two possiblity values 'css_classes' or 'html_data_attrs'.
+    The 'anchors_fields' in the property_fields attributes can add choices id elements of the current page, theses
+    choices are realy set when the request is available.
     """
+    
     def __new__(cls, *args):
         form_fields = {}
+        form_fields_by_property_name = {}
+        form_fields_by_attr_type = {}
+        fields_choices_anchors = []
+
         for arg in args:
             if isinstance(arg, property):
-                form_fields.update(arg.fget(cls))
+                property_fields=arg.fget(cls)
+                form_subfields = property_fields['form_fields']
+                attrs_type = property_fields['attrs_type']
+                property_name = property_fields['property_name']
+
+                form_fields.update(form_subfields)
+                form_fields_by_property_name[property_name]= property_fields['form_fields']
+                form_fields_by_attr_type.setdefault(attrs_type, [])
+                form_fields_by_attr_type[attrs_type ].extend(property_fields['form_fields'].keys())
+                if 'anchors_fields' in  property_fields:
+                    fields_choices_anchors.extend(property_fields['anchors_fields'])
 
         class Meta:
-            entangled_fields = {'glossary': list(form_fields.keys())}
+            entangled_fields = {'glossary': list(form_fields) }
 
-        utility_form_mixin = type('UtilitiesFormMixin', (EntangledModelFormMixin,), dict(form_fields, Meta=Meta))
-        return type('BootstrapUtilitiesMixin', (CascadeUtilitiesMixin,), {'utility_form_mixin': utility_form_mixin})
+        utility_form_mixin = type('UtilitiesFormMixin', (EntangledModelFormMixin,), dict(form_fields, Meta=Meta) )
+        return type('HtmlAttrsUtilitiesMixin', (CascadeUtilitiesMixin,), {'utility_form_mixin': utility_form_mixin,
+                     'attr_type': form_fields_by_attr_type , 'fields_with_choices_anchors': fields_choices_anchors })
 
     @property
     def background_and_color(cls):
+        attrs_type = 'css_classes'
+        property_name = 'background_and_color'
         choices = [
             ('', _("Default")),
             ('bg-primary text-white', _("Primary with white text")),
@@ -57,15 +80,19 @@ class BootstrapUtilities(type):
             ('bg-transparent text-dark', _("Transparent with dark text")),
             ('bg-transparent text-white', _("Transparent with white text")),
         ]
-        return {'background_and_color': ChoiceField(
+        form_fields = {'background_and_color': ChoiceField(
             label=_("Background and color"),
             choices=choices,
             required=False,
             initial='',
         )}
+        property_fields = { 'form_fields':form_fields, 'attrs_type': attrs_type, 'property_name':property_name }
+        return property_fields 
 
     @property
     def margins(cls):
+        attrs_type = 'css_classes'
+        property_name = 'margins'
         form_fields = {}
         choices_format = [
             ('m-{}{}', _("4 sided margins ({})")),
@@ -91,10 +118,13 @@ class BootstrapUtilities(type):
                 required=False,
                 initial='',
             )
-        return form_fields
+        property_fields = { 'form_fields':form_fields, 'attrs_type': attrs_type, 'property_name':property_name }
+        return property_fields 
 
     @property
     def vertical_margins(cls):
+        attrs_type = 'css_classes'
+        property_name = 'vertical_margins'
         form_fields = {}
         choices_format = [
             ('my-{}{}', _("Vertical margins ({})")),
@@ -116,10 +146,13 @@ class BootstrapUtilities(type):
                 required=False,
                 initial='',
             )
-        return form_fields
+        property_fields = { 'form_fields':form_fields, 'attrs_type': attrs_type, 'property_name':property_name }
+        return property_fields 
 
     @property
     def paddings(cls):
+        attrs_type = 'css_classes'
+        property_name = 'paddings'
         form_fields = {}
         choices_format = [
             ('p-{}{}', _("4 sided padding ({})")),
@@ -145,11 +178,14 @@ class BootstrapUtilities(type):
                 required=False,
                 initial='',
             )
-        return form_fields
+        property_fields = { 'form_fields':form_fields, 'attrs_type': attrs_type, 'property_name':property_name }
+        return property_fields 
 
     @property
     def floats(cls):
         form_fields = {}
+        attrs_type = 'css_classes'
+        property_name = 'floats'
         choices_format = [
             ('float-{}none', _("Do not float")),
             ('float-{}left', _("Float left")),
@@ -169,4 +205,6 @@ class BootstrapUtilities(type):
                 required=False,
                 initial='',
             )
-        return form_fields
+        property_fields = { 'form_fields':form_fields, 'attrs_type': attrs_type, 'property_name':property_name }
+        return property_fields 
+

--- a/cmsplugin_cascade/generic/mixins.py
+++ b/cmsplugin_cascade/generic/mixins.py
@@ -102,3 +102,4 @@ class SectionMixin(object):
             cms_page.cascadepage.glossary.setdefault('element_ids', {})
             cms_page.cascadepage.glossary['element_ids'][str(obj.pk)] = element_id
             cms_page.cascadepage.save()
+

--- a/cmsplugin_cascade/generic/mixins_html_attrs.py
+++ b/cmsplugin_cascade/generic/mixins_html_attrs.py
@@ -1,0 +1,109 @@
+from django.forms.fields import ChoiceField
+from django.utils.text import format_lazy
+from django.utils.translation import ugettext_lazy as _
+from entangled.forms import EntangledModelFormMixin
+from cmsplugin_cascade.utils import CascadeUtilitiesMixin
+from cmsplugin_cascade.bootstrap4.grid import Breakpoint
+from django.contrib.admin.utils import flatten
+from cmsplugin_cascade import app_settings
+
+class HtmlAttrsUtilities(type):
+    """
+    Factory for building a class ``HtmlAttrsUtilitiesMixin``. This class then is used as a mixin to
+    all sorts of generic plugins. Various plugins are shipped using this mixin class
+    in different configurations. These configurations can be overridden through the project's
+    settings using:
+    ```
+    CMSPLUGIN_CASCADE['plugins_with_extra_mixins'] = {
+        'Bootstrap<ANY>Plugin': HtmlAttrsUtilities(
+            HtmlAttrsUtilities.scroll_animate,
+            …
+        ),
+        …
+    }
+    ```
+
+    The class ``HtmlAttrsUtilities`` offers a bunch of property methods which return a list of
+    input fields and/or select boxes. They then can be added to the plugin's editor. 
+    Specficed with attritbute in property methods 'attrs_type' with two possible values 'css_classes' or 'html_data_attrs'
+    Html data attribute need some time anchors of current page.
+    form_fields has reserved string '#anchors' used with choices='#anchors', after the form request anchor of element_ids
+    are disponible in choicesfields.
+    """
+    def __new__(cls, *args):
+        form_fields = {}
+        form_fields_by_property_name = {}
+        form_fields_by_attr_type = {}
+        fields_choices_anchors = []
+
+        for arg in args:
+            if isinstance(arg, property):
+                property_fields=arg.fget(cls)
+                form_subfields = property_fields['form_fields']
+                attrs_type = property_fields['attrs_type']
+                property_name = property_fields['property_name']
+
+                form_fields.update(form_subfields)
+                form_fields_by_property_name[property_name]= property_fields['form_fields']
+                form_fields_by_attr_type.setdefault(attrs_type, [])
+                form_fields_by_attr_type[attrs_type ].extend(property_fields['form_fields'].keys())
+                if 'anchors_fields' in  property_fields:
+                    fields_choices_anchors.extend(property_fields['anchors_fields'])
+
+        class Meta:
+            entangled_fields = {'glossary': list(form_fields) }
+
+        utility_form_mixin = type('UtilitiesFormMixin', (EntangledModelFormMixin,), dict(form_fields, Meta=Meta) )
+        return type('HtmlAttrsUtilitiesMixin', (CascadeUtilitiesMixin,), {'utility_form_mixin': utility_form_mixin,
+                     'attr_type': form_fields_by_attr_type , 'fields_with_choices_anchors': fields_choices_anchors })
+
+    @property
+    def scroll_animate(cls):
+        form_fields = {}
+        attrs_type = 'html_data_attrs'
+        property_name = 'scroll_animate'
+
+        choices_data_sal = [
+            ('inherit', _("inherit")),
+            ('fade', _("fade")),
+            ('slide-up', _("slide-up")),
+            ('slide-down', _("slide-down")),
+            ('slide-left', _("slide-left")),
+            ('slide-right', _("slide-right")),
+            ('zoom-in', _("zoom-in")),
+            ('zoom-out', _("zoom-out")),
+            ('flip-up', _("flip-up")),
+            ('flip-down', _("flip-down")),
+            ('zoom-out', _("zoom-out")),
+            ('flip-up', _("flip-up")),
+            ('flip-right', _("flip-right")),
+        ]
+
+        choices_data_sal_delay= [(c, c) for c in ["inherit"] + [i for i in range(0, 2100, 100)]]
+        choices_data_sal_easing= [
+            ('ease', _("ease")),
+            ('ease-in-out-back', _("ease-in-out-back")),
+            ('ease-out-back', _("ease-out-back")),
+            ('ease-in-out-sine', _("ease-in-out-sine")),
+            ('ease-in-quad', _("ease-in-quad")),
+        ]
+        form_fields['data-sal'] = ChoiceField(
+                        label=_("Scroll effects"),
+                        choices=choices_data_sal,
+                        required=False,
+                        initial='',
+                    )
+        form_fields['data-sal-delay'] = ChoiceField(
+                        label=_("Delay effect"),
+                        choices= choices_data_sal_delay,
+                        required=False,
+                        initial='',
+                        help_text='Delay in milliseconde',
+                    )
+        form_fields['data-sal-easing'] = ChoiceField(
+                        label=_("Animation type"),
+                        choices=choices_data_sal_easing,
+                        required=False,
+                        initial='',
+                    )
+        return { 'form_fields':form_fields, 'attrs_type': attrs_type, 'property_name':property_name }

--- a/cmsplugin_cascade/generic/mixins_html_attrs.py
+++ b/cmsplugin_cascade/generic/mixins_html_attrs.py
@@ -7,23 +7,23 @@ from cmsplugin_cascade.bootstrap4.grid import Breakpoint
 from django.contrib.admin.utils import flatten
 from cmsplugin_cascade import app_settings
 
-class HtmlAttrsUtilities(type):
+class GenericUtilities(type):
     """
-    Factory for building a class ``HtmlAttrsUtilitiesMixin``. This class then is used as a mixin to
+    Factory for building a class ``GenericUtilitiesMixin``. This class then is used as a mixin to
     all sorts of generic plugins. Various plugins are shipped using this mixin class
     in different configurations. These configurations can be overridden through the project's
     settings using:
     ```
     CMSPLUGIN_CASCADE['plugins_with_extra_mixins'] = {
-        'Bootstrap<ANY>Plugin': HtmlAttrsUtilities(
-            HtmlAttrsUtilities.scroll_animate,
+        'Bootstrap<ANY>Plugin': GenericUtilities(
+            GenericUtilities.scroll_animate,
             …
         ),
         …
     }
     ```
 
-    The class ``HtmlAttrsUtilities`` offers a bunch of property methods which return a list of
+    The class ``GenericUtilities`` offers a bunch of property methods which return a list of
     input fields and/or select boxes. They then can be added to the plugin's editor. 
     Specficed with attritbute in property methods 'attrs_type' with two possible values 'css_classes' or 'html_data_attrs'
     Html data attribute need some time anchors of current page.
@@ -54,7 +54,7 @@ class HtmlAttrsUtilities(type):
             entangled_fields = {'glossary': list(form_fields) }
 
         utility_form_mixin = type('UtilitiesFormMixin', (EntangledModelFormMixin,), dict(form_fields, Meta=Meta) )
-        return type('HtmlAttrsUtilitiesMixin', (CascadeUtilitiesMixin,), {'utility_form_mixin': utility_form_mixin,
+        return type('GenericUtilitiesMixin', (CascadeUtilitiesMixin,), {'utility_form_mixin': utility_form_mixin,
                      'attr_type': form_fields_by_attr_type , 'fields_with_choices_anchors': fields_choices_anchors })
 
     @property

--- a/cmsplugin_cascade/utils.py
+++ b/cmsplugin_cascade/utils.py
@@ -86,23 +86,41 @@ class CascadeUtilitiesMixin(metaclass=MediaDefiningClass):
     """
     If a Cascade plugin is listed in ``settings.CMSPLUGIN_CASCADE['plugins_with_extra_mixins']``,
     then this ``BootstrapUtilsMixin`` class is added automatically to its plugin class in order to
-    enrich it with utility classes, such as :class:`cmsplugin_cascade.bootstrap4.mixins.BootstrapUtilities`.
+    enrich it with utility classes or html_attrs, such as :class:`cmsplugin_cascade.bootstrap4.mixins.BootstrapUtilities`.
+    If anchor_fields is specified in the property_fields attributes, these attribute choices are set when the request 
+    is available whit id elements of the current page.
+
     """
+
     def __str__(self):
         return self.plugin_class.get_identifier(self)
 
     def get_form(self, request, obj=None, **kwargs):
         form = kwargs.get('form', self.form)
+        for anchors_field  in self.fields_with_choices_anchors:
+            currentpage_element_ids =  obj.page.cascadepage.glossary.get('element_ids', {})
+            self.utility_form_mixin.base_fields[anchors_field].choices=[[items,value] for items, value  in currentpage_element_ids.items()]
         assert issubclass(form, EntangledModelFormMixin), "Form must inherit from EntangledModelFormMixin"
         kwargs['form'] = type(form.__name__, (self.utility_form_mixin, form), {})
         return super().get_form(request, obj, **kwargs)
 
+
     @classmethod
     def get_css_classes(cls, obj):
-        """Enrich list of CSS classes with customized ones"""
         css_classes = super().get_css_classes(obj)
-        for utility_field_name in cls.utility_form_mixin.base_fields.keys():
-            css_class = obj.glossary.get(utility_field_name)
-            if css_class:
-                css_classes.append(css_class)
+        if 'css_classes' in  cls.attr_type:
+            for utility_field_name in cls.attr_type['css_classes']:
+                css_class = obj.glossary.get(utility_field_name)
+                if css_class:
+                    css_classes.append(css_class)
         return css_classes
+
+    @classmethod
+    def get_html_tag_attributes(cls, obj):
+        attributes = super().get_html_tag_attributes(obj)
+        if 'html_data_attrs' in  cls.attr_type:
+            for utility_field_name in cls.attr_type['html_data_attrs']:
+                attribute = obj.glossary.get(utility_field_name)
+                if attribute:
+                    attributes.update({utility_field_name:attribute})
+        return attributes

--- a/cmsplugin_cascade/utils.py
+++ b/cmsplugin_cascade/utils.py
@@ -98,8 +98,11 @@ class CascadeUtilitiesMixin(metaclass=MediaDefiningClass):
     def get_form(self, request, obj=None, **kwargs):
         form = kwargs.get('form', self.form)
         for anchors_field  in self.fields_with_choices_anchors:
-            currentpage_element_ids =  obj.page.cascadepage.glossary.get('element_ids', {})
-            self.utility_form_mixin.base_fields[anchors_field].choices=[[items,value] for items, value  in currentpage_element_ids.items()]
+            if hasattr(obj.page,'cascadepage'):
+                currentpage_element_ids =  obj.page.cascadepage.glossary.get('element_ids', {})
+                self.utility_form_mixin.base_fields[anchors_field].choices=[[items,value] for items, value  in currentpage_element_ids.items()]
+            else:
+                self.utility_form_mixin.base_fields[anchors_field].choices=[]
         assert issubclass(form, EntangledModelFormMixin), "Form must inherit from EntangledModelFormMixin"
         kwargs['form'] = type(form.__name__, (self.utility_form_mixin, form), {})
         return super().get_form(request, obj, **kwargs)

--- a/examples/bs4demo/settings.py
+++ b/examples/bs4demo/settings.py
@@ -7,6 +7,8 @@ import sys
 from django.urls import reverse_lazy
 
 from cmsplugin_cascade.extra_fields.config import PluginExtraFieldsConfig
+from cmsplugin_cascade.bootstrap4.mixins import BootstrapUtilities
+from cmsplugin_cascade.generic.mixins_html_attrs import HtmlAttrsUtilities
 from django.utils.text import format_lazy
 
 DEBUG = True
@@ -223,6 +225,10 @@ CMSPLUGIN_CASCADE = {
     'allow_plugin_hiding': True,
     'leaflet': {'default_position': {'lat': 50.0, 'lng': 12.0, 'zoom': 6}},
     'cache_strides': True,
+    'plugins_with_extra_mixins': {
+    'BootstrapColumnPlugin':BootstrapUtilities(BootstrapUtilities.background_and_color, BootstrapUtilities.floats, BootstrapUtilities.vertical_margins, BootstrapUtilities.paddings, BootstrapUtilities.margins,
+     HtmlAttrsUtilities.scroll_animate ),
+    },
 }
 
 CMS_PLACEHOLDER_CONF = {

--- a/examples/bs4demo/settings.py
+++ b/examples/bs4demo/settings.py
@@ -8,7 +8,7 @@ from django.urls import reverse_lazy
 
 from cmsplugin_cascade.extra_fields.config import PluginExtraFieldsConfig
 from cmsplugin_cascade.bootstrap4.mixins import BootstrapUtilities
-from cmsplugin_cascade.generic.mixins_html_attrs import HtmlAttrsUtilities
+from cmsplugin_cascade.generic.mixins_html_attrs import GenericUtilities
 from django.utils.text import format_lazy
 
 DEBUG = True
@@ -227,7 +227,7 @@ CMSPLUGIN_CASCADE = {
     'cache_strides': True,
     'plugins_with_extra_mixins': {
     'BootstrapColumnPlugin':BootstrapUtilities(BootstrapUtilities.background_and_color, BootstrapUtilities.floats, BootstrapUtilities.vertical_margins, BootstrapUtilities.paddings, BootstrapUtilities.margins,
-     HtmlAttrsUtilities.scroll_animate ),
+     GenericUtilities.scroll_animate ),
     },
 }
 

--- a/examples/bs4demo/templates/bs4demo/base.html
+++ b/examples/bs4demo/templates/bs4demo/base.html
@@ -52,6 +52,14 @@
 	<script src="{% static 'node_modules/popper.js/dist/umd/popper.js' %}" type="text/javascript"></script>
 	<script src="{% static 'node_modules/bootstrap/dist/js/bootstrap.min.js' %}" type="text/javascript"></script>
 	{% endif %}
+	<script src="{% static 'node_modules/intersection-observer/intersection-observer.js' %}" type="text/javascript"></script>
+	<script src="{% static 'node_modules/sal.js/dist/sal.js' %}" type="text/javascript"></script>
+	<script  type="text/javascript">
+		sal({
+			threshold: 1,
+			once: false,
+		});
+	</script>
 	{% render_block "js" %}
 </body>
 

--- a/examples/bs4demo/templates/bs4demo/base.html
+++ b/examples/bs4demo/templates/bs4demo/base.html
@@ -60,6 +60,18 @@
 			once: false,
 		});
 	</script>
+	{% if request.toolbar and request.toolbar.edit_mode_active %}
+		<script>
+		$(function() {
+			CMS.$(window).on('cms-content-refresh', function () {
+				sal({
+					threshold: 1,
+					once: false,
+				});
+			});
+		});
+		</script>
+	{% endif %}
 	{% render_block "js" %}
 </body>
 

--- a/examples/bs4demo/templates/bs4demo/main.html
+++ b/examples/bs4demo/templates/bs4demo/main.html
@@ -2,7 +2,11 @@
 {% load static cms_tags bootstrap_tags sekizai_tags sass_tags %}
 
 {% block head %}
-{% addtoblock "css" %}<link rel="stylesheet" href="{% sass_src 'bs4demo/css/main.scss' %}" type="text/css" />{% endaddtoblock %}
+{% addtoblock "css" %}
+<link rel="stylesheet" href="{% sass_src 'bs4demo/css/main.scss' %}" type="text/css" />
+<link rel="stylesheet" href="{% static 'node_modules/sal.js/dist/sal.css' %}" type="text/css" />
+{% endaddtoblock %}
+
 {% endblock head %}
 
 {% block header %}

--- a/examples/package.json
+++ b/examples/package.json
@@ -11,14 +11,16 @@
     "angular": "^1.5.11",
     "angular-animate": "^1.5.11",
     "angular-sanitize": "^1.5.11",
-    "ui-bootstrap4": "^3.0.5",
     "bootstrap": "^4.1.3",
+    "intersection-observer": "^0.7.0",
     "jquery": "^3.2.1",
     "leaflet": "^1.2.0",
     "leaflet-easybutton": "^2.2.0",
     "picturefill": "^3.0.2",
     "popper.js": "^1.12.9",
-    "select2": "^4.0.3"
+    "sal.js": "^0.6.5",
+    "select2": "^4.0.3",
+    "ui-bootstrap4": "^3.0.5"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
>  Sal (Scroll Animation Library) was created to provide a performant and lightweight solution for animating elements on scroll. It's based on the Intersection Observer, which gives amazing performance in terms of checking the element's presence in the viewport.
https://github.com/mciastek/sal
https://github.com/w3c/IntersectionObserver/tree/master/polyfill

In this, BootstrapUtilities give choice for property attr_type (css_classes or html_data_attrs)
Bootstrap4 is concerned with this with for example:

> Scrollspy:
> Automatically update Bootstrap navigation or list group components based on scroll position to indicate which link is currently active in the viewport.
https://getbootstrap.com/docs/4.0/components/scrollspy/

and for more generic:
GenericUtilities give same possibility as BootstrapUtilities but for generic library.

If it suits you, would you like it to be optional, like when the npm package  sal.js is present?

The fonction` __new__ ` is duplicated, we could remove it from BootstrapUtilities and use it like this,  (this impacts the settings and should be branded deprecated for a while.) :
```
CMSPLUGIN_CASCADE = {
..
    'plugins_with_extra_mixins': {
        'BootstrapColumnPlugin': GenericUtilities(
        BootstrapUtilities.background_and_color,
        BootstrapUtilities.paddings,
        GenericUtilities.scroll_animate
        ),
     },
}
```


demo:
![Peek 16-12-2019 14-55](https://user-images.githubusercontent.com/344493/70913402-3c399f00-2016-11ea-86d9-e88e25c15343.gif)
