### PR TITLE
Fix column initial field for first breakpoint

### DIFF
--- a/cmsplugin_cascade/bootstrap4/container.py
+++ b/cmsplugin_cascade/bootstrap4/container.py
@@ -233,7 +233,7 @@ class BootstrapColumnPlugin(BootstrapPluginBase):
                 width_fields[field_name] = ChoiceField(
                     choices=choices,
                     label=_("Column width for {}").format(devices),
-                    initial='col-{}-12'.format(bp),
+                    initial='col' if bp == 'xs' else 'col-{}'.format(bp),
                     help_text=choose_help_text(
                         _("Column width for devices narrower than {:.1f} pixels."),
                         _("Column width for devices wider than {:.1f} pixels."),


### PR DESCRIPTION
Bootstrap4 to specific.
Default are Flex.
This is necessary if we are not using the default widget.